### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ docker run --rm -d --name stress-tests --privileged -v /dev:/dev -v /tmp:/tmp 
 Check if the stress tests started successfully:
 
 ```
-$ docker logs stress-tests 
+$ docker logs stress-tests
 Setting up stress tests...
 RT stress tests started successfully!
 ```
@@ -61,7 +61,11 @@ Run the following command to execute the `rt-tests` container and start measurin
 $ docker run --rm -it --name rt-tests --cap-add=sys_nice --cap-add=ipc_lock --cap-add=sys_rawio --ulimit rtprio=99 --device-cgroup-rule='c 10:* rmw' -v /dev:/dev -v /tmp:/tmp torizon/rt-tests:$CT_TAG_RT_TESTS
 ```
 
-The tests will run for at most 12 hours, but can be interrupted at any time by pressing CTRL-C.
+The tests will run for at most 12 hours, but can be interrupted at any time by
+pressing CTRL-C. You can specify a different length of the test run in seconds
+by passing the environment variable *DURATION* to the container (with
+`-e DURATION=…`); for other units append `m` for minutes, `h` for hours and `d`
+for days.
 
 After the tests are finished, stop the `stress-tests` container:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ ls /mnt/pendrive/file.tar
 Run the following command to execute the `stress-tests` container:
 
 ```
-$ docker run --rm -d --name stress-tests --privileged -v /dev:/dev -v /tmp:/tmp -v /mnt/pendrive/:/mnt/pendrive torizon/stress-tests:$CT_TAG_STRESS_TESTS
+$ docker run --rm -d --name stress-tests --privileged -v /mnt/pendrive/:/mnt/pendrive torizon/stress-tests:$CT_TAG_STRESS_TESTS
 ```
 
 Check if the stress tests started successfully:
@@ -58,7 +58,7 @@ RT stress tests started successfully!
 Run the following command to execute the `rt-tests` container and start measuring the latency:
 
 ```
-$ docker run --rm -it --name rt-tests --cap-add=sys_nice --cap-add=ipc_lock --cap-add=sys_rawio --ulimit rtprio=99 --device-cgroup-rule='c 10:* rmw' -v /dev:/dev -v /tmp:/tmp torizon/rt-tests:$CT_TAG_RT_TESTS
+$ docker run --rm -it --name rt-tests --cap-add=ipc_lock --ulimit rtprio=99 -v /tmp:/tmp torizon/rt-tests:$CT_TAG_RT_TESTS
 ```
 
 The tests will run for at most 12 hours, but can be interrupted at any time by
@@ -102,7 +102,7 @@ A latency plot from cyclictest histogram data will be available in `/tmp/latency
 Running the `rt-tests` container on a non-PREEMPT_RT version of TorizonCore may be useful to compare the results with the PREEMPT_RT version. But if you try to run, the execution might fail:
 
 ```
-$ docker run --rm -it --name rt-tests --cap-add=sys_nice --cap-add=ipc_lock --cap-add=sys_rawio --ulimit rtprio=99 --device-cgroup-rule='c 10:* rmw' -v /dev:/dev -v /tmp:/tmp torizon/rt-tests:$CT_TAG_RT_TESTS
+$ docker run --rm -it --name rt-tests --cap-add=ipc_lock --ulimit rtprio=99 -v /tmp:/tmp torizon/rt-tests:$CT_TAG_RT_TESTS
 Unable to change scheduling policy!
 Probably missing capabilities, either run as root or increase RLIMIT_RTPRIO limits.
 ERROR: cyclictest failed
@@ -114,5 +114,5 @@ So if you want to run the `rt-tests` container on a non-PREEMPT_RT version of To
 
 ```
 sudo sh -c "echo 950000 > /sys/fs/cgroup/cpu,cpuacct/docker/cpu.rt_runtime_us"
-docker run --rm -it --name rt-tests --cpu-rt-runtime=950000 --cap-add=sys_nice --cap-add=ipc_lock --cap-add=sys_rawio --ulimit rtprio=99 --device-cgroup-rule='c 10:* rmw' -v /dev:/dev -v /tmp:/tmp torizon/rt-tests:$CT_TAG_RT_TESTS
+docker run --rm -it --name rt-tests --cpu-rt-runtime=950000 --cap-add=ipc_lock --ulimit rtprio=99 -v /tmp:/tmp torizon/rt-tests:$CT_TAG_RT_TESTS
 ```

--- a/rt-tests/Dockerfile
+++ b/rt-tests/Dockerfile
@@ -3,8 +3,9 @@ ARG IMAGE_ARCH=linux/arm
 ARG IMAGE_TAG=2-bullseye
 FROM --platform=$IMAGE_ARCH torizon/debian:$IMAGE_TAG
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gnuplot rt-tests \
+RUN apt update \
+    && apt install -y --no-install-recommends gnuplot rt-tests \
+    && apt clean
     && rm -rf /var/lib/apt/lists/*
 
 COPY rt-tests.sh /rt-tests.sh

--- a/rt-tests/rt-tests.sh
+++ b/rt-tests/rt-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Run cyclictest
-if ! cyclictest -S -p99 -i1000 -m -D12h -h400 -q >output; then
+if ! cyclictest -S -p99 -i1000 -m -D${DURATION:-12h} -h400 -q >output; then
   echo "ERROR: cyclictest failed" >&2
   exit 1
 fi

--- a/rt-tests/rt-tests.sh
+++ b/rt-tests/rt-tests.sh
@@ -16,8 +16,7 @@ grep -v -e "^#" -e "^$" output | tr " " "\t" >histogram
 cores=$(grep -c ^processor /proc/cpuinfo)
 for i in `seq 1 $cores`
 do
-  column=`expr $i + 1`
-  cut -f1,$column histogram >histogram$i
+  cut -f1,$(( $i + 1 )) histogram >histogram$i
 done
 
 # Create plot command header
@@ -38,7 +37,7 @@ do
   then
     echo -n ", " >>plotcmd
   fi
-  cpuno=`expr $i - 1`
+  cpuno=$(( $i - 1 ))
   if test $cpuno -lt 10
   then
     title=" CPU$cpuno"

--- a/stress-tests/Dockerfile
+++ b/stress-tests/Dockerfile
@@ -3,8 +3,9 @@ ARG IMAGE_ARCH=linux/arm
 ARG IMAGE_TAG=2-bullseye
 FROM --platform=$IMAGE_ARCH torizon/debian:$IMAGE_TAG
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends iperf3 rt-tests iputils-ping \
+RUN apt update \
+    && apt install -y --no-install-recommends iperf3 rt-tests iputils-ping \
+    && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
 COPY stress-tests.sh /stress-tests.sh

--- a/stress-tests/Dockerfile
+++ b/stress-tests/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_TAG=2-bullseye
 FROM --platform=$IMAGE_ARCH torizon/debian:$IMAGE_TAG
 
 RUN apt update \
-    && apt install -y --no-install-recommends iperf3 rt-tests iputils-ping \
+    && apt install -y --no-install-recommends iperf3 rt-tests iputils-ping iproute2 \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/stress-tests/stress-tests.sh
+++ b/stress-tests/stress-tests.sh
@@ -13,10 +13,9 @@ for dev in /dev/mmcblk? /dev/sd?; do
 done
 
 # I/O load (USB read/write)
-if mount | grep /mnt/pendrive >/dev/null; then
+if mount | grep -q /mnt/pendrive; then
     if [ -e /mnt/pendrive/file.tar ]; then
         cd /mnt/pendrive
-        tar -cf file.tar -C /var/log --exclude=lost+found -p .
         while true; do rm -rf output; mkdir -p output; tar xfv file.tar -C output/ >/dev/null 2>&1; done &
     else
         echo "Warning: Archive file.tar not found in /mnt/pendrive. USB read/write stress test will not run."


### PR DESCRIPTION
The major changes are:

* adding the environment variable *DURATION* to control the duration of test runs
* fixing #2 
* improve stressing: I used [atop](https://www.atoptool.nl/) to monitor the system while the test run, and it didn't show exhaustion. The hackbench didn't take all the CPU, and storage and network were not utilized either.

BTW: How about adding a COPYRIGHT file to address #1? Would you be fine with Apache Licence?